### PR TITLE
Return keycloak's server response

### DIFF
--- a/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
+++ b/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
@@ -19,7 +19,7 @@ export async function fetchWithError(
 
   if (!response.ok) {
     const responseData = await parseResponse(response);
-    throw new NetworkError("Network response was not OK.", {
+    throw new NetworkError(responseData, {
       response,
       responseData,
     });


### PR DESCRIPTION
Simple change to see actual keycloak server error message and not a generic message.

Original generic message looks like this:

```
Error: Network response was not OK.
     at fetchWithError (file:///usr/src/app/node_modules/@keycloak/keycloak-admin-client/lib/utils/fetchWithError.js:14:15)
```

With this change you get the actual errors:
```
Error: {"errorMessage":"User exists with same username"}
     at fetchWithError (file:///usr/src/app/node_modules/@keycloak/keycloak-admin-client/lib/utils/fetchWithError.js:14:15)
```
```
Error: {"error":"HTTP 401 Unauthorized","error_description":"For more on this error consult the server log at the debug level."}
     at fetchWithError (file:///usr/src/app/node_modules/@keycloak/keycloak-admin-client/lib/utils/fetchWithError.js:14:15)
```
